### PR TITLE
複数種類の通知機能を追加

### DIFF
--- a/6_1/ch14/app/controllers/account_activations_controller.rb
+++ b/6_1/ch14/app/controllers/account_activations_controller.rb
@@ -4,8 +4,8 @@ class AccountActivationsController < ApplicationController
     user = User.find_by(email: params[:email])
     if user && !user.activated? && user.authenticated?(:activation, params[:id])
       user.activate
-      Notification.build!(user: user, category: :login)
       log_in user
+      Notification.build!(user: user, category: :login)
       flash[:success] = "Account activated!"
       redirect_to user
     else

--- a/6_1/ch14/app/controllers/account_activations_controller.rb
+++ b/6_1/ch14/app/controllers/account_activations_controller.rb
@@ -4,6 +4,7 @@ class AccountActivationsController < ApplicationController
     user = User.find_by(email: params[:email])
     if user && !user.activated? && user.authenticated?(:activation, params[:id])
       user.activate
+      Notification.build!(user: user, category: :login)
       log_in user
       flash[:success] = "Account activated!"
       redirect_to user

--- a/6_1/ch14/app/controllers/relationships_controller.rb
+++ b/6_1/ch14/app/controllers/relationships_controller.rb
@@ -4,6 +4,7 @@ class RelationshipsController < ApplicationController
   def create
     @user = User.find(params[:followed_id])
     current_user.follow(@user)
+    Notification.build!(user: @user, category: :followed, follower: current_user)
     respond_to do |format|
       format.html { redirect_to @user }
       format.js

--- a/6_1/ch14/app/models/followed_notification_builder.rb
+++ b/6_1/ch14/app/models/followed_notification_builder.rb
@@ -1,0 +1,59 @@
+class FollowedNotificationBuilder
+  def initialize(user:, follower:)
+    @user = user
+    @follower = follower
+  end
+
+  def build!
+    if notification_within_5_minutes.nil?
+      build_on_first_time!
+    else
+      update_message!(notification_within_5_minutes)
+    end
+  end
+
+  private
+
+  def notification_within_5_minutes
+    @notification_within_5_minutes ||= Notification.where(
+        user: @user,
+        category: :followed
+      ).where(
+        'updated_at > ?', Time.current - 5.minutes
+      ).order(updated_at: :desc)
+      .first
+  end
+
+  def build_on_first_time!
+    Notification.create!(
+      user: @user,
+      category: :followed,
+      message: first_followed_message
+    )
+  end
+
+  def first_followed_message
+    "#{@follower.name}さんにフォローされました"
+  end
+
+  def update_message!(notification)
+    if recent_followers_count.zero?
+      message = first_followed_message
+    else
+      message = "#{first_follower(notification.message)}さん他#{recent_followers_count}名にフォローされました"
+    end
+    notification.update!(message: message)
+  end
+
+  def first_follower(message)
+    if message.match(/\A(.*?)さん他(\d+)名にフォローされました\z/)
+      $1
+    elsif message.match(/\A(.*?)さんにフォローされました\z/)
+      $1
+    end
+  end 
+
+  def recent_followers_count
+    @recent_followers_count ||= Relationship.recent_followers_count(@user.id)
+  end
+end

--- a/6_1/ch14/app/models/followed_notification_builder.rb
+++ b/6_1/ch14/app/models/followed_notification_builder.rb
@@ -1,3 +1,4 @@
+# ユーザーがフォローされたときの通知を作成
 class FollowedNotificationBuilder
   def initialize(user:, follower:)
     @user = user
@@ -37,12 +38,15 @@ class FollowedNotificationBuilder
   end
 
   def update_message!(notification)
+    notification.update!(message: updated_message(notification))
+  end
+
+  def updated_message(notification)
     if recent_followers_count.zero?
-      message = first_followed_message
+      first_followed_message
     else
-      message = "#{first_follower(notification.message)}さん他#{recent_followers_count}名にフォローされました"
+      "#{first_follower(notification.message)}さん他#{recent_followers_count}名にフォローされました"
     end
-    notification.update!(message: message)
   end
 
   def first_follower(message)

--- a/6_1/ch14/app/models/login_notification_builder.rb
+++ b/6_1/ch14/app/models/login_notification_builder.rb
@@ -1,16 +1,17 @@
+# 初回ログインされたときの通知を作成する
 class LoginNotificationBuilder
   def initialize(user:)
     @user = user
   end
 
   def build!
-    return if exists_notice?
+    return if exist_notification?
     Notification.create!(user: @user, category: :login, message: '初回ログインありがとうございます。')
   end
 
   private
 
-  def exists_notice?
+  def exist_notification?
     Notification.where(user: @user, category: :login).exists?
   end
 end

--- a/6_1/ch14/app/models/login_notification_builder.rb
+++ b/6_1/ch14/app/models/login_notification_builder.rb
@@ -1,0 +1,16 @@
+class LoginNotificationBuilder
+  def initialize(user:)
+    @user = user
+  end
+
+  def build!
+    return if exists_notice?
+    Notification.create!(user: @user, category: :login, message: '初回ログインありがとうございます。')
+  end
+
+  private
+
+  def exists_notice?
+    Notification.where(user: @user, category: :login).exists?
+  end
+end

--- a/6_1/ch14/app/models/notification.rb
+++ b/6_1/ch14/app/models/notification.rb
@@ -2,4 +2,11 @@ class Notification < ApplicationRecord
   belongs_to :user
   enum category: [:login, :followed]
   validates :message, presence: true
+
+  def self.build!(user:, category:)
+    if category == :login
+      builder = LoginNotificationBuilder.new(user: user)
+      builder.build!
+    end
+  end
 end

--- a/6_1/ch14/app/models/notification.rb
+++ b/6_1/ch14/app/models/notification.rb
@@ -1,3 +1,4 @@
+# 通知
 class Notification < ApplicationRecord
   belongs_to :user
   enum category: [:login, :followed]

--- a/6_1/ch14/app/models/notification.rb
+++ b/6_1/ch14/app/models/notification.rb
@@ -3,9 +3,12 @@ class Notification < ApplicationRecord
   enum category: [:login, :followed]
   validates :message, presence: true
 
-  def self.build!(user:, category:)
+  def self.build!(user:, category:, follower: nil)
     if category == :login
       builder = LoginNotificationBuilder.new(user: user)
+      builder.build!
+    elsif category == :followed
+      builder = FollowedNotificationBuilder.new(user: user, follower: follower)
       builder.build!
     end
   end

--- a/6_1/ch14/app/models/notification.rb
+++ b/6_1/ch14/app/models/notification.rb
@@ -1,0 +1,5 @@
+class Notification < ApplicationRecord
+  belongs_to :user
+  enum category: [:login, :followed]
+  validates :message, presence: true
+end

--- a/6_1/ch14/app/models/relationship.rb
+++ b/6_1/ch14/app/models/relationship.rb
@@ -3,4 +3,21 @@ class Relationship < ApplicationRecord
   belongs_to :followed, class_name: "User"
   validates :follower_id, presence: true
   validates :followed_id, presence: true
+
+  # フォローされたときの通知メッセージ「○○さん他?人にフォローされました」表示用の人数
+  # NOTE: 
+  #   コーディングテスト用のため、フォロアーが大人数になるケースは想定していません。
+  #   フォロアーが1000人を超えるなどの場合は、重くなる可能性があります。
+  def self.recent_followers_count(followed_id)
+    relations = Relationship.where(followed_id: followed_id).order(created_at: :desc)
+    created_at = relations.first.created_at
+    count = 0
+    relations.each do |relation|
+      next if relation.created_at == created_at
+      break if relation.created_at < created_at - 5.minutes
+      count += 1
+      created_at = relation.created_at
+    end
+    count
+  end
 end

--- a/6_1/ch14/db/migrate/20211228011109_create_notifications.rb
+++ b/6_1/ch14/db/migrate/20211228011109_create_notifications.rb
@@ -1,0 +1,12 @@
+class CreateNotifications < ActiveRecord::Migration[6.1]
+  def change
+    create_table :notifications do |t|
+      t.references :user, null: false, foreign_key: true
+      t.integer :category, null: false, defalut: 0
+      t.string :message, null: false
+
+      t.timestamps
+    end
+    add_index :notifications, [:user_id, :created_at]
+  end
+end

--- a/6_1/ch14/db/schema.rb
+++ b/6_1/ch14/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_30_032413) do
+ActiveRecord::Schema.define(version: 2021_12_28_011109) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -49,6 +49,16 @@ ActiveRecord::Schema.define(version: 2021_11_30_032413) do
     t.index ["user_id"], name: "index_microposts_on_user_id"
   end
 
+  create_table "notifications", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "category", null: false
+    t.string "message", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id", "created_at"], name: "index_notifications_on_user_id_and_created_at"
+    t.index ["user_id"], name: "index_notifications_on_user_id"
+  end
+
   create_table "relationships", force: :cascade do |t|
     t.integer "follower_id"
     t.integer "followed_id"
@@ -78,4 +88,5 @@ ActiveRecord::Schema.define(version: 2021_11_30_032413) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "microposts", "users"
+  add_foreign_key "notifications", "users"
 end

--- a/6_1/ch14/test/fixtures/notifications.yml
+++ b/6_1/ch14/test/fixtures/notifications.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  category: 1
+  message: MyString
+
+two:
+  user: two
+  category: 1
+  message: MyString

--- a/6_1/ch14/test/integration/following_test.rb
+++ b/6_1/ch14/test/integration/following_test.rb
@@ -38,6 +38,14 @@ class FollowingTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "フォロー後の通知データを確認" do
+    post relationships_path, params: { followed_id: @other.id }
+    notification = Notification.last
+    assert_equal @other.id, notification.user_id
+    assert_equal "followed", notification.category
+    assert_equal "Michael Exampleさんにフォローされました", notification.message
+  end
+
   test "should unfollow a user the standard way" do
     @user.follow(@other)
     relationship = @user.active_relationships.find_by(followed_id: @other.id)

--- a/6_1/ch14/test/integration/users_signup_test.rb
+++ b/6_1/ch14/test/integration/users_signup_test.rb
@@ -4,6 +4,7 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
 
   def setup
     ActionMailer::Base.deliveries.clear
+    @notification_count = Notification.count
   end
 
   test "invalid signup information" do
@@ -43,5 +44,10 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_template 'users/show'
     assert is_logged_in?
+    assert_equal @notification_count + 1, Notification.count
+    notification = Notification.last
+    assert_equal user.id, notification.user_id
+    assert notification.login?
+    assert_equal '初回ログインありがとうございます。', notification.message 
   end
 end

--- a/6_1/ch14/test/models/followed_notification_builder_test.rb
+++ b/6_1/ch14/test/models/followed_notification_builder_test.rb
@@ -1,0 +1,81 @@
+require "test_helper"
+
+class FollowedNotificationBuilderTest < ActiveSupport::TestCase
+  def setup
+    Notification.where(category: :followed).destroy_all
+    Relationship.destroy_all
+
+    @user_michael = users(:michael)
+    @user_archer = users(:archer)
+    @user_lana = users(:lana)
+    @user_malory = users(:malory)
+  end
+
+  test "初回フォローされたとき" do
+    builder = FollowedNotificationBuilder.new(user: @user_michael, follower: @user_archer)
+    builder.build!
+    notification = Notification.last
+    assert_equal @user_michael.id, notification.user_id
+    assert_equal "followed", notification.category
+    assert_equal "Sterling Archerさんにフォローされました", notification.message
+  end
+
+  test "5分以内に2人目からフォローをされたとき" do
+    # 1人目のフォロー
+    @user_archer.follow(@user_michael)
+    FollowedNotificationBuilder.new(user: @user_michael, follower: @user_archer).build!
+
+    # 2人目のフォロー
+    @user_lana.follow(@user_michael)
+    FollowedNotificationBuilder.new(user: @user_michael, follower: @user_lana).build!
+
+    notification = Notification.last
+    assert_equal @user_michael.id, notification.user_id
+    assert_equal "followed", notification.category
+    assert_equal "Sterling Archerさん他1名にフォローされました", notification.message
+  end
+
+  test "5分以内に3人目からフォローをされたとき" do
+    # 1人目のフォロー
+    @user_archer.follow(@user_michael)
+    FollowedNotificationBuilder.new(user: @user_michael, follower: @user_archer).build!
+
+    # 2人目のフォロー
+    @user_lana.follow(@user_michael)
+    FollowedNotificationBuilder.new(user: @user_michael, follower: @user_lana).build!
+
+    # 3人目のフォロー
+    @user_malory.follow(@user_michael)
+    FollowedNotificationBuilder.new(user: @user_michael, follower: @user_malory).build!
+
+    notification = Notification.last
+    assert_equal @user_michael.id, notification.user_id
+    assert_equal "followed", notification.category
+    assert_equal "Sterling Archerさん他2名にフォローされました", notification.message
+  end
+
+  test "5分以上間をあけて2人目からフォローされたとき" do
+    notification_count = Notification.count
+
+    # 1人目のフォロー
+    @user_archer.follow(@user_michael)
+    FollowedNotificationBuilder.new(user: @user_michael, follower: @user_archer).build!
+
+    # 最新の通知の更新時間を6分前にする
+    notification = Notification.last
+    notification.update!(updated_at: Time.current - 6.minutes)
+
+    # 2人目のフォロー
+    @user_lana.follow(@user_michael)
+    FollowedNotificationBuilder.new(user: @user_michael, follower: @user_lana).build!
+
+    notification = Notification.last
+    assert_equal @user_michael.id, notification.user_id
+    assert_equal "followed", notification.category
+    assert_equal "Lana Kaneさんにフォローされました", notification.message
+
+    # notificationsレコードが2件増えていること
+    assert_equal 2, Notification.count - notification_count
+  end
+
+end

--- a/6_1/ch14/test/models/notification_test.rb
+++ b/6_1/ch14/test/models/notification_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class NotificationTest < ActiveSupport::TestCase
+  def setup
+    user = User.create!(name: "Example User", email: "user@example.com",
+      password: "foobar", password_confirmation: "foobar")
+    @notification = Notification.new(user_id: user.id, category: 0, message: '初回ログインありがとうございます。')
+  end
+
+  test "should be valid" do
+    assert @notification.valid?
+  end
+
+  test "user_id should be present" do
+    @notification.user_id = nil
+    assert_not @notification.valid?
+  end
+
+  test "message should be present" do
+    @notification.message = nil
+    assert_not @notification.valid?
+  end
+end

--- a/6_1/ch14/test/models/notification_test.rb
+++ b/6_1/ch14/test/models/notification_test.rb
@@ -2,9 +2,7 @@ require "test_helper"
 
 class NotificationTest < ActiveSupport::TestCase
   def setup
-    user = User.create!(name: "Example User", email: "user@example.com",
-      password: "foobar", password_confirmation: "foobar")
-    @notification = Notification.new(user_id: user.id, category: 0, message: '初回ログインありがとうございます。')
+    @notification = Notification.new(user_id: users(:michael).id, category: :login, message: '初回ログインありがとうございます。')
   end
 
   test "should be valid" do
@@ -19,5 +17,17 @@ class NotificationTest < ActiveSupport::TestCase
   test "message should be present" do
     @notification.message = nil
     assert_not @notification.valid?
+  end
+
+  test "Notification.build! 初回ログイン時、通知が作成されること" do
+    count = Notification.count
+    Notification.build!(user: users(:michael), category: :login)
+    assert_equal count + 1, Notification.count
+  end
+
+  test "Notification.build! フォローされたとき、通知が作成されること" do
+    count = Notification.count
+    Notification.build!(user: users(:michael), category: :followed, follower: users(:archer))
+    assert_equal count + 1, Notification.count
   end
 end

--- a/6_1/ch14/test/models/relationship_test.rb
+++ b/6_1/ch14/test/models/relationship_test.rb
@@ -20,4 +20,20 @@ class RelationshipTest < ActiveSupport::TestCase
     @relationship.followed_id = nil
     assert_not @relationship.valid?
   end
+
+  test "Relationship.recent_followers_count" do
+    Relationship.destroy_all
+    @relationship.save
+
+    Relationship.create!(
+      follower_id: users(:lana).id,
+      followed_id: users(:archer).id
+    )
+    Relationship.create!(
+      follower_id: users(:archer).id,
+      followed_id: users(:lana).id
+    )
+    assert_equal 1, Relationship.recent_followers_count(users(:archer).id) # :archer は :michael他1名からフォローされている
+    assert_equal 0, Relationship.recent_followers_count(users(:lana).id)   # :lana は 1名からしかフォローされていない
+  end
 end


### PR DESCRIPTION
# 概要
「Rails複数種類通知」コーディングテスト提出物です。

https://github.com/SchooLynk/sample_apps/tree/main/6_1/ch14
よりforkして作成しています。

# 追加したテーブル
- notifications 「通知情報」テーブルを作成しています。

| カラム名 | 型 | 説明 |
| ---- | ---- | ---- |
| id | integer | プライマリキー |
| user_id | integer | users.id |
| category | integer | 0: 初回ログイン時の通知 1:フォローされたときの通知 |
| message | string | 通知用メッセージ |

# 要件
（https://doorkel.notion.site/Rails-12314ece71fb487dbd414f67106cb18b より引用）

```
1. フォローされた際に通知が作られる（「○○さんにフォローされました」）
2. 初回ログイン時に通知が作られる（「初回ログインありがとうございます。」）
3. 5分以内に同じ種類の通知が発生する場合は一つの通知にまとめられる（「○○さん他3名にフォローされました」）
4. 1,2,3の通知を同じUIで一覧できる

但し、通知を確認するControllerやViewは作らなくてOK。データが作られる所までをコーディングテストのスコープとする。
```

# 要件の4について
「1,2,3の通知を同じUIで一覧できる」・・・同じテーブルで、ユーザーIDで検索すると該当ユーザー宛ての通知が取得できます。ControllerやViewは作らなくてOKということでしたので、こちらの対応とさせて頂きました。

# 対応していないこと、実装で迷った点など
- フォローを外したときの考慮はしていません。
AさんがBさんをフォローし、その後すぐにフォローを外した場合も、Bさん宛ての通知で「Aさんからフォローされました」という通知は残ります。
- フォローされたときの通知が直近5分以内であればまとめる・・ということでしたので、relationsテーブルから「最新のフォロアーからデータを遡り、間隔が5分以上空いていない人の人数」をカウントしています。
5分以内に10人にフォローされ、うち2人がフォローをすぐに外した場合は「○○さん他7名からフォローされました」という通知になるはずです。
・・とはいえ、厳密にフォローを外したときのパターンを網羅していません。
基本的にはフォロアーが増えるときの通知のみテストしています。
